### PR TITLE
Include SessionToken in generated s3 credentials

### DIFF
--- a/server/s3.coffee
+++ b/server/s3.coffee
@@ -63,4 +63,5 @@ Meteor.methods
       RoleSessionName: 'temporary-credentials'
     accessKey = creds.Credentials.AccessKeyId
     secretKey = creds.Credentials.SecretAccessKey
-    "aws_access_key_id=#{accessKey};aws_secret_access_key=#{secretKey}"
+    token = creds.Credentials.SessionToken
+    "aws_access_key_id=#{accessKey};aws_secret_access_key=#{secretKey};token=#{token}"


### PR DESCRIPTION
As per [Redshift COPY docs](http://docs.aws.amazon.com/redshift/latest/dg/r_COPY.html) and [`assume-role` docs](http://docs.aws.amazon.com/cli/latest/reference/sts/assume-role.html). All three strings are required to use temporary credentials.